### PR TITLE
[feat] update docker-compose and README for mongo and mongo-express setup

### DIFF
--- a/Services/text-service/.env.example
+++ b/Services/text-service/.env.example
@@ -1,0 +1,2 @@
+MONGO_DB=mongodb://root:12345@localhost:27017/
+PORT=5001

--- a/Services/text-service/README.md
+++ b/Services/text-service/README.md
@@ -1,0 +1,80 @@
+# Text Service — Quick onboarding
+
+Follow these steps to get the local database and web UI running. This is a short, numbered onboarding for local development.
+
+Prerequisites
+
+- Docker Desktop must be installed and running.
+- Clone or navigate to this repo and open a terminal in this folder.
+
+## 1. Open terminal and go to the service folder
+
+```pwsh
+cd d:\Repos\TypeRushService\Services\text-service
+```
+
+## 2. Start the stack
+
+- For foreground logs (handy while developing):
+
+```pwsh
+docker compose up
+```
+
+- For background (daemon) mode:
+
+```pwsh
+docker compose up -d
+```
+
+## 3. Verify services are running
+
+```pwsh
+docker ps
+docker compose ps
+```
+
+You should see two services: `mongo` (27017) and `mongo-express` (8081).
+
+## 4. Open mongo-express UI and login
+
+- Open your browser to: http://localhost:8081/
+- When prompted for HTTP Basic Auth, use:
+  - Username: admin
+  - Password: 12345
+
+## 5. Quick checks if something’s wrong
+
+- If the page doesn't load, check Docker and container status:
+
+```pwsh
+docker compose logs -f
+```
+
+- Check mongo logs specifically:
+
+```pwsh
+docker compose logs -f mongo
+```
+
+- If ports are already in use, change the port mappings in `docker-compose.yaml` or stop the conflicting process.
+
+## 6. Stop and clean up
+
+```pwsh
+docker compose down
+```
+
+## 7. Connection strings
+
+- From the host (apps running on host):
+
+```
+MONGO_DB=mongodb://root:12345@localhost:27017/
+```
+
+- From other containers inside this compose network use:
+
+```
+mongodb://root:12345@mongo:27017/
+```

--- a/Services/text-service/docker-compose.yaml
+++ b/Services/text-service/docker-compose.yaml
@@ -1,22 +1,22 @@
 name: typerush-textservice-deployment
 
 services:
-  # typerush-textservice:
-  #   image: hatohui/typerush-textservice:latest
-  #   build: .
-  #   container_name: typerush-textservice
-  #   ports:
-  #     - "8000:8000"
-  #   environment:
-  #     - LOG_OUTPUT_URL=http://log-output:8080/logs
-  #   restart: always
-  typerush-textservice-db:
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: 12345
+
+  mongo-express:
     image: mongo-express
     restart: always
     ports:
       - 8081:8081
     environment:
-      ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/
+      ME_CONFIG_MONGODB_URL: mongodb://root:12345@mongo:27017/
       ME_CONFIG_BASICAUTH_ENABLED: true
-      ME_CONFIG_BASICAUTH_USERNAME: mongoexpressuser
-      ME_CONFIG_BASICAUTH_PASSWORD: mongoexpresspass
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: 12345


### PR DESCRIPTION
- More details can be found in README.md
- resolves #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added onboarding guide for the Text Service local stack, including prerequisites, start/stop commands, verification steps, troubleshooting, cleanup, and connection string guidance. Also documents access to the Mongo Express UI.
- Chores
  - Introduced an example environment file with default database URI and service port.
  - Updated the local Docker setup to include MongoDB and Mongo Express, refreshed connection strings, and standardized default credentials for local usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->